### PR TITLE
Fix dummy files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem 'rspec'
+gem 'simplecov', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,34 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
+
+PLATFORMS
+  x86_64-darwin-21
+
+DEPENDENCIES
+  rspec
+  simplecov
+
+BUNDLED WITH
+   2.3.14

--- a/data/game_teams_dummy.csv
+++ b/data/game_teams_dummy.csv
@@ -8,3 +8,12 @@ game_id,team_id,HoA,result,settled_in,head_coach,goals,shots,tackles,pim,powerPl
 2012030224,6,away,WIN,OT,Claude Julien,3,10,24,8,4,2,53.7,8,6
 2012030224,3,home,LOSS,OT,John Tortorella,2,8,40,8,4,1,46.3,9,7
 2012030225,3,away,LOSS,REG,John Tortorella,1,7,25,13,2,1,50.9,5,3
+2012030225,6,home,WIN,REG,Claude Julien,3,8,35,11,3,1,49.1,12,9
+2012030311,6,away,WIN,REG,Claude Julien,3,7,19,17,4,0,66.7,1,5
+2012030311,5,home,LOSS,REG,Dan Bylsma,0,7,34,28,4,0,33.3,8,9
+2012030312,6,away,WIN,REG,Claude Julien,4,7,19,6,1,0,50.9,2,5
+2012030312,5,home,LOSS,REG,Dan Bylsma,1,6,37,4,2,0,49.1,12,5
+2012030313,5,away,LOSS,OT,Dan Bylsma,1,13,46,16,6,0,57.3,8,10
+2012030313,6,home,WIN,OT,Claude Julien,2,10,34,18,5,0,42.7,10,13
+2012030314,5,away,LOSS,REG,Dan Bylsma,0,6,33,8,3,0,47.5,8,1
+2012030314,6,home,WIN,REG,Claude Julien,1,6,25,8,3,0,52.5,11,5

--- a/data/game_teams_dummy.csv
+++ b/data/game_teams_dummy.csv
@@ -1,0 +1,10 @@
+game_id,team_id,HoA,result,settled_in,head_coach,goals,shots,tackles,pim,powerPlayOpportunities,powerPlayGoals,faceOffWinPercentage,giveaways,takeaways
+2012030221,3,away,LOSS,OT,John Tortorella,2,8,44,8,3,0,44.8,17,7
+2012030221,6,home,WIN,OT,Claude Julien,3,12,51,6,4,1,55.2,4,5
+2012030222,3,away,LOSS,REG,John Tortorella,2,9,33,11,5,0,51.7,1,4
+2012030222,6,home,WIN,REG,Claude Julien,3,8,36,19,1,0,48.3,16,6
+2012030223,6,away,WIN,REG,Claude Julien,2,8,28,6,0,0,61.8,10,7
+2012030223,3,home,LOSS,REG,John Tortorella,1,6,37,2,2,0,38.2,7,9
+2012030224,6,away,WIN,OT,Claude Julien,3,10,24,8,4,2,53.7,8,6
+2012030224,3,home,LOSS,OT,John Tortorella,2,8,40,8,4,1,46.3,9,7
+2012030225,3,away,LOSS,REG,John Tortorella,1,7,25,13,2,1,50.9,5,3

--- a/data/games_dummy.csv
+++ b/data/games_dummy.csv
@@ -1,0 +1,10 @@
+game_id,season,type,date_time,away_team_id,home_team_id,away_goals,home_goals,venue,venue_link
+2012030221,20122013,Postseason,5/16/13,3,6,2,3,Toyota Stadium,/api/v1/venues/null
+2012030222,20122013,Postseason,5/19/13,3,6,2,3,Toyota Stadium,/api/v1/venues/null
+2012030223,20122013,Postseason,5/21/13,6,3,2,1,BBVA Stadium,/api/v1/venues/null
+2012030224,20122013,Postseason,5/23/13,6,3,3,2,BBVA Stadium,/api/v1/venues/null
+2012030225,20122013,Postseason,5/25/13,3,6,1,3,Toyota Stadium,/api/v1/venues/null
+2012030311,20122013,Postseason,6/2/13,6,5,3,0,Children's Mercy Park,/api/v1/venues/null
+2012030312,20122013,Postseason,6/4/13,6,5,4,1,Children's Mercy Park,/api/v1/venues/null
+2012030313,20122013,Postseason,6/6/13,5,6,1,2,Toyota Stadium,/api/v1/venues/null
+2012030314,20122013,Postseason,6/8/13,5,6,0,1,Toyota Stadium,/api/v1/venues/null

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,0 +1,6 @@
+class StatTracker 
+
+  def self.from_csv(locations)
+    StatTracker.new
+  end
+end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,6 +1,21 @@
-class StatTracker 
+require 'csv'
+
+class StatTracker
+  attr_reader :games,
+              :teams,
+              :game_teams
+
+  def initialize(games, teams, game_teams)
+    @games = games
+    @teams = teams
+    @game_teams = game_teams
+  end
 
   def self.from_csv(locations)
-    StatTracker.new
+    games = CSV.table(locations[:games], converters: :all)
+    teams = CSV.table(locations[:teams], converters: :all)
+    game_teams = CSV.table(locations[:game_teams], converters: :all)
+    StatTracker.new(games, teams, game_teams)
   end
+
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -18,4 +18,9 @@ class StatTracker
     StatTracker.new(games, teams, game_teams)
   end
 
+  def average_goals_per_game
+    total_goals = @games.sum{ |game| game[:away_goals] + game[:home_goals] }
+    (total_goals.to_f / @games.length).round(2)
+  end
+
 end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -18,6 +18,10 @@ class StatTracker
     StatTracker.new(games, teams, game_teams)
   end
 
+  def highest_total_score
+    @games.map{|game| game[:away_goals] + game[:home_goals]}.max
+  end
+
   def average_goals_per_game
     total_goals = @games.sum{ |game| game[:away_goals] + game[:home_goals] }
     (total_goals.to_f / @games.length).round(2)

--- a/runner.rb
+++ b/runner.rb
@@ -1,0 +1,15 @@
+require './lib/stat_tracker'
+
+game_path = './data/games.csv'
+team_path = './data/teams.csv'
+game_teams_path = './data/game_teams.csv'
+
+locations = {
+  games: game_path,
+  teams: team_path,
+  game_teams: game_teams_path
+}
+
+stat_tracker = StatTracker.from_csv(locations)
+
+require 'pry'; binding.pry

--- a/runner.rb
+++ b/runner.rb
@@ -12,4 +12,6 @@ locations = {
 
 stat_tracker = StatTracker.from_csv(locations)
 
-require 'pry'; binding.pry
+# require 'pry'; binding.pry
+
+# p stat_tracker.games.shift[:away_goals]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'simplecov'
+SimpleCov.start
+

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -3,9 +3,9 @@ require './lib/stat_tracker'
 RSpec.describe StatTracker do
   context 'Iteration 1' do
     before :each do
-      game_path = './data/games.csv'
+      game_path = './data/games_dummy.csv'
       team_path = './data/teams.csv'
-      game_teams_path = './data/game_teams.csv'
+      game_teams_path = './data/game_teams_dummy.csv'
 
       locations = {
         games: game_path,

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.game_teams).to be_an_instance_of(CSV::Table)
     end
 
+    it 'show highest_total_score' do
+      expect(@stat_tracker.highest_total_score).to eq(5)
+    end
+
     it 'can return the number average_goals_per_game' do
       expect(@stat_tracker.average_goals_per_game).to eq(3.78)
     end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -1,0 +1,31 @@
+require './lib/stat_tracker'
+
+RSpec.describe StatTracker do
+  context 'Iteration 1' do
+    before :each do
+      game_path = './data/games.csv'
+      team_path = './data/teams.csv'
+      game_teams_path = './data/game_teams.csv'
+
+      locations = {
+        games: game_path,
+        teams: team_path,
+        game_teams: game_teams_path
+      }
+
+      @stat_tracker = StatTracker.from_csv(locations)
+    end
+
+    it 'exists' do
+
+      expect(@stat_tracker).to be_an_instance_of(StatTracker)
+    end
+
+    it 'has data' do
+
+      expect(@stat_tracker.games).to be_an_instance_of(CSV::Table)
+      expect(@stat_tracker.teams).to be_an_instance_of(CSV::Table)
+      expect(@stat_tracker.game_teams).to be_an_instance_of(CSV::Table)
+    end
+  end
+end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -27,5 +27,10 @@ RSpec.describe StatTracker do
       expect(@stat_tracker.teams).to be_an_instance_of(CSV::Table)
       expect(@stat_tracker.game_teams).to be_an_instance_of(CSV::Table)
     end
+
+    it 'can return the number average_goals_per_game' do
+      expect(@stat_tracker.average_goals_per_game).to eq(3.78)
+    end
+
   end
 end


### PR DESCRIPTION
I changed the game_teams_dummy.csv file to detail the same games as the games_dummy.csv file.

Since game_teams.csv lists each game twice (one entry for each team playing), the number of lines (excluding headers) is twice as long as the games.csv